### PR TITLE
fix base image

### DIFF
--- a/Dockerfile-py3-gpu
+++ b/Dockerfile-py3-gpu
@@ -1,4 +1,4 @@
-FROM microsoft/cntk:.4-gpu-python3.5-cuda9.0-cudnn7.0
+FROM microsoft/cntk:2.4-gpu-python3.5-cuda9.0-cudnn7.0
 
 LABEL maintainer "MICROSOFT CORPORATION"
 


### PR DESCRIPTION
Unable to build docker gpu image because base image in dockerfile has a typo.